### PR TITLE
Implement circular route functionality

### DIFF
--- a/src/main/java/org/cubexmc/metro/listener/PlayerMoveListener.java
+++ b/src/main/java/org/cubexmc/metro/listener/PlayerMoveListener.java
@@ -190,9 +190,9 @@ public class PlayerMoveListener implements Listener {
             }
         }
         
-        final String finalTitle = TextUtil.replacePlaceholders(title, line, stop, lastStop, nextStop, terminalStop, lineManager);
-        final String finalSubtitle = TextUtil.replacePlaceholders(subtitle, line, stop, lastStop, nextStop, terminalStop, lineManager);
-        final String finalActionbar = TextUtil.replacePlaceholders(actionbar, line, stop, lastStop, nextStop, terminalStop, lineManager);
+        final String finalTitle = TextUtil.replacePlaceholders(title, line, stop, lastStop, nextStop, terminalStop, lineManager, plugin.getStopManager());
+        final String finalSubtitle = TextUtil.replacePlaceholders(subtitle, line, stop, lastStop, nextStop, terminalStop, lineManager, plugin.getStopManager());
+        final String finalActionbar = TextUtil.replacePlaceholders(actionbar, line, stop, lastStop, nextStop, terminalStop, lineManager, plugin.getStopManager());
 
         if (alwaysShow) {
             Object actionBarTaskId = SchedulerUtil.globalRun(plugin, new Runnable() {

--- a/src/main/java/org/cubexmc/metro/train/TrainMovementTask.java
+++ b/src/main/java/org/cubexmc/metro/train/TrainMovementTask.java
@@ -691,7 +691,7 @@ public class TrainMovementTask implements Runnable {
                 String actionbarText = actionbarTemplate.replace("{countdown}", String.valueOf(secondsLeft));
                 
                 // 替换其他占位符
-                actionbarText = TextUtil.replacePlaceholders(actionbarText, line, mainStop, prevStop, nextStop, terminusStop, lineManager);
+                actionbarText = TextUtil.replacePlaceholders(actionbarText, line, mainStop, prevStop, nextStop, terminusStop, lineManager, plugin.getStopManager());
                 
                 // 转换颜色代码
                 actionbarText = ChatColor.translateAlternateColorCodes('&', actionbarText);
@@ -747,9 +747,9 @@ public class TrainMovementTask implements Runnable {
         }
         
         // 使用TextUtil替换占位符
-        String title = TextUtil.replacePlaceholders(titleTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager);
-        String subtitle = TextUtil.replacePlaceholders(subtitleTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager);
-        String actionbar = TextUtil.replacePlaceholders(actionbarTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager);
+        String title = TextUtil.replacePlaceholders(titleTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager, plugin.getStopManager());
+        String subtitle = TextUtil.replacePlaceholders(subtitleTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager, plugin.getStopManager());
+        String actionbar = TextUtil.replacePlaceholders(actionbarTemplate, line, mainStop, prevStop, nextStop, terminusStop, lineManager, plugin.getStopManager());
         
         // 转换颜色代码
         title = ChatColor.translateAlternateColorCodes('&', title);
@@ -835,8 +835,8 @@ public class TrainMovementTask implements Runnable {
         }
         
         // 替换标题占位符
-        String title = TextUtil.replacePlaceholders(titleTemplate, line, currentStop, null, nextStop, terminusStop, lineManager);
-        String subtitle = TextUtil.replacePlaceholders(subtitleTemplate, line, currentStop, null, nextStop, terminusStop, lineManager);
+        String title = TextUtil.replacePlaceholders(titleTemplate, line, currentStop, null, nextStop, terminusStop, lineManager, plugin.getStopManager());
+        String subtitle = TextUtil.replacePlaceholders(subtitleTemplate, line, currentStop, null, nextStop, terminusStop, lineManager, plugin.getStopManager());
         
         // 转换颜色代码
         title = ChatColor.translateAlternateColorCodes('&', title);
@@ -861,7 +861,7 @@ public class TrainMovementTask implements Runnable {
             startCountdownActionbar("waiting", currentStop, null, nextStop, terminusStop);
         } else {
             // 如果没有倒计时，显示静态actionbar
-            String actionbarText = TextUtil.replacePlaceholders(actionbarTemplate, line, currentStop, null, nextStop, terminusStop, lineManager);
+            String actionbarText = TextUtil.replacePlaceholders(actionbarTemplate, line, currentStop, null, nextStop, terminusStop, lineManager, plugin.getStopManager());
             actionbarText = ChatColor.translateAlternateColorCodes('&', actionbarText);
             passenger.spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(actionbarText));
         }

--- a/src/main/resources/lines.yml
+++ b/src/main/resources/lines.yml
@@ -3,15 +3,37 @@
 # 格式:
 # line_id:
 #   name: 线路显示名称
-#   ordered_platform_ids: 
+#   ordered_platform_ids:  (注: 在新版本中建议使用 ordered_stop_ids, 功能相同)
 #     - platform_id1
 #     - platform_id2
 #     ...
+#   color: "&a"  (可选, 线路颜色代码, 默认为 &f 白色)
+#   terminus_name: "自定义终点站显示名" (可选, 用于信息展示)
+#
+# 环线 (Circular Routes):
+# 要定义一条环线，请确保 ordered_stop_ids 列表中的第一个和最后一个 stop_id 相同。
+# 例如: [stopA, stopB, stopC, stopA]
+# 对于环线:
+#   - 如果设置了 terminus_name, 则会使用该名称。
+#   - 如果未设置 terminus_name, 系统将自动使用下一站的名称作为方向指引（例如 “开往 [下一站名称] 方向”）。
+#   - 至少需要定义三个站点ID（例如 A -> B -> A）才能构成有效的环线。
 #
 # 示例:
 # line1:
 #   name: 1号线 - 东西向
-#   ordered_platform_ids:
+#   ordered_stop_ids: # 旧版 ordered_platform_ids 仍可兼容
 #     - east_station_north_platform
 #     - central_station_east_platform
-#     - west_station_south_platform 
+#     - west_station_south_platform
+#   color: "&e"
+#   terminus_name: "西站"
+#
+# line_circle_example:
+#   name: 环线示例
+#   ordered_stop_ids:
+#     - stop_alpha
+#     - stop_beta
+#     - stop_gamma
+#     - stop_alpha # 第一个和最后一个ID相同，构成环线
+#   color: "&b"
+#   # terminus_name: "内环" # 如果不设置此项，则会显示开往下一站


### PR DESCRIPTION
- Allow metro lines to be defined as circular by having the first and last stop ID be the same in `lines.yml`.
- Modified `Line.java` to correctly calculate next/previous stops for circular routes via `isCircular()`, `getNextStopId()`, and `getPreviousStopId()`.
- Updated `TextUtil.java` so that for circular lines without an explicit `terminus_name` in `lines.yml`, the `{terminus_name}` placeholder will resolve to the name of the next stop.
- Callers in `PlayerMoveListener.java` and `TrainMovementTask.java` updated to provide necessary `StopManager` instance to `TextUtil`.
- Added documentation in `lines.yml` explaining how to configure circular routes and the behavior of `terminus_name`.